### PR TITLE
chore: add .podspec file

### DIFF
--- a/notificare-push-lib-react-native.podspec
+++ b/notificare-push-lib-react-native.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/Notificare/notificare-push-lib-react-native.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
Hi there ,

i have created `.podspec` to the project to enable `Autolink` for iOS project.

the current version is giving this error message when you try to run `pod install`
```
[!] use_native_modules! skipped the react-native dependency 'notificare-push-lib-react-native'. No podspec file was found.
    - Check to see if there is an updated version that contains the necessary podspec file
    - Contact the library maintainers or send them a PR to add a podspec. The react-native-webview podspec is a good example of a
    package.json driven podspec. See
    https://github.com/react-native-community/react-native-webview/blob/master/react-native-webview.podspec
```